### PR TITLE
Fix bash error when container cannot be pulled

### DIFF
--- a/toolbox
+++ b/toolbox
@@ -126,7 +126,8 @@ run() {
 }
 
 cleanup() {
-    if [ $(container_active) -eq 0 ] && [ -z "$NO_STOP" ]; then
+    active="$(container_active)"
+    if [ $active != "" ] && [ $active -eq 0 ] && [ -z "$NO_STOP" ]; then
 	${SUDO} $CLI stop "$TOOLBOX_NAME" &>/dev/null
     fi
 }


### PR DESCRIPTION
Fixes https://github.com/openSUSE/microos-toolbox/issues/48, where toolbox reports a bash error when the container cannot be pulled.