### PR TITLE
Mount /dev/pts as mount type=devpts instead of --volume

### DIFF
--- a/toolbox
+++ b/toolbox
@@ -195,7 +195,7 @@ stop() {
 container_create() {
     if [ -z "$SANDBOX" ]; then
         # this is the default behavior, unless --sandbox is specified
-        CREATE_NO_SANDBOX="--volume /dev:/dev:rslave --volume /sys:/sys:rslave --volume /:/media/root:rslave"
+        CREATE_NO_SANDBOX="--mount type=devpts,destination=/dev/pts,uid=$(id -u) --volume /sys:/sys:rslave --volume /:/media/root:rslave"
         CREATE_NO_SANDBOX="$CREATE_NO_SANDBOX --privileged --security-opt label=disable --pid host --ipc host"
     fi
     if ! ${SUDO} $CLI create \

--- a/toolbox
+++ b/toolbox
@@ -47,7 +47,7 @@ setup() {
 }
 
 create() {
-    local msg="creat"
+    local msg="create"
     if ! container_exists; then
         if ! image_exists || [ -z "$NO_PULL" ]; then
             image_pull

--- a/toolbox
+++ b/toolbox
@@ -54,7 +54,7 @@ create() {
         fi
         local runlabel
         runlabel=$(image_runlabel) ||:
-	
+
         echo "Spawning a container '$TOOLBOX_NAME' with image '$TOOLBOX_IMAGE'"
         if [[ -z "$runlabel" ]]; then
             container_create


### PR DESCRIPTION
Mounting /dev/ into the container via `--volume /dev:/dev:rslave` does not work with podman + crun, as it dies with:
```
Error: crun: chown `/dev/pts/22`: Operation not permitted: OCI permission denied
```

This is very closely related to the issue reported by containers/toolbox against crun (https://github.com/containers/crun/issues/1158) where a bug in crun was fixed and the suggested way how to expose a tty is to use `--mount type=devpts,destination=/dev/pts,uid=$ID`